### PR TITLE
OPENEUROPA-2296: Add required dependency to module.

### DIFF
--- a/oe_link_lists.info.yml
+++ b/oe_link_lists.info.yml
@@ -4,3 +4,5 @@ package: OpenEuropa
 
 type: module
 core: 8.x
+dependencies:
+  - drupal:node


### PR DESCRIPTION
## OPENEUROPA-2296
### Description

Link lists links require the node module to work.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

