### PR TITLE
OPENEUROPA-2512: Make sure the manual links source respects the limit parameter.

### DIFF
--- a/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
+++ b/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
@@ -124,6 +124,10 @@ class ManualLinkSource extends LinkSourcePluginBase implements ContainerFactoryP
       return new LinkCollection();
     }
 
+    if ($limit !== NULL) {
+      $ids = array_slice($ids, $offset, $limit);
+    }
+
     $link_entities = $this->entityTypeManager->getStorage('link_list_link')->loadMultipleRevisions(array_column($ids, 'entity_revision_id'));
     $event = new ManualLinksResolverEvent($link_entities);
     $this->eventDispatcher->dispatch(ManualLinksResolverEvent::NAME, $event);

--- a/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
+++ b/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
@@ -124,10 +124,7 @@ class ManualLinkSource extends LinkSourcePluginBase implements ContainerFactoryP
       return new LinkCollection();
     }
 
-    if ($limit !== NULL) {
-      $ids = array_slice($ids, $offset, $limit);
-    }
-
+    $ids = array_slice($ids, $offset, $limit);
     $link_entities = $this->entityTypeManager->getStorage('link_list_link')->loadMultipleRevisions(array_column($ids, 'entity_revision_id'));
     $event = new ManualLinksResolverEvent($link_entities);
     $this->eventDispatcher->dispatch(ManualLinksResolverEvent::NAME, $event);

--- a/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
+++ b/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
@@ -57,6 +57,59 @@ class ManualLinkSourcePluginTest extends KernelTestBase {
     ]);
 
     $this->createContentType(['type' => 'page']);
+
+  }
+
+  /**
+   * Tests the getLinks() method.
+   *
+   * @covers ::getLinks
+   */
+  public function testGetLinks(): void {
+    // Create a node to be used by an internal link.
+    $node_one = $this->createNode(['type' => 'page']);
+
+    // Create an internal link and an external link.
+    $entity_type_manager = $this->container->get('entity_type.manager');
+    $link_storage = $entity_type_manager->getStorage('link_list_link');
+    $internal_link_one = $link_storage->create([
+      'bundle' => 'internal',
+      'target' => $node_one->id(),
+      'status' => 1,
+    ]);
+    $internal_link_one->save();
+
+    $external_link = $link_storage->create([
+      'bundle' => 'external',
+      'url' => 'http://example.com',
+      'title' => 'Example title',
+      'teaser' => 'Example teaser',
+      'status' => 1,
+    ]);
+    $external_link->save();
+
+    // Create a list that references one internal and one external link.
+    $list_storage = $entity_type_manager->getStorage('link_list');
+    $list = $list_storage->create([
+      'bundle' => 'manual',
+      'links' => [
+        $external_link,
+        $internal_link_one,
+      ],
+      'status' => 1,
+    ]);
+    $list->save();
+
+    $plugin_manager = $this->container->get('plugin.manager.oe_link_lists.link_source');
+    /** @var \Drupal\oe_link_lists_manual_source\Plugin\LinkSource\ManualLinkSource $plugin */
+    $plugin_configuration = $list->getConfiguration()['source']['plugin_configuration'];
+    $plugin = $plugin_manager->createInstance('manual_links', $plugin_configuration);
+
+    $links = $plugin->getLinks();
+
+    // Assert we can filter the amount of links we get.
+    $this->assertCount(2, $plugin->getLinks());
+    $this->assertCount(1, $plugin->getLinks(1));
   }
 
   /**

--- a/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
+++ b/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
@@ -106,10 +106,19 @@ class ManualLinkSourcePluginTest extends KernelTestBase {
     $plugin = $plugin_manager->createInstance('manual_links', $plugin_configuration);
 
     $links = $plugin->getLinks();
+    $this->assertCount(2, $links);
+    $this->assertEquals('Example title', $links[0]->getTitle());
+    $this->assertEquals($node_one->label(), $links[1]->getTitle());
 
     // Assert we can filter the amount of links we get.
-    $this->assertCount(2, $plugin->getLinks());
-    $this->assertCount(1, $plugin->getLinks(1));
+    $links = $plugin->getLinks(1);
+    $this->assertCount(1, $links);
+    $this->assertEquals('Example title', $links[0]->getTitle());
+
+    // Verify the offset.
+    $links = $plugin->getLinks(NULL, 1);
+    $this->assertCount(1, $links);
+    $this->assertEquals($node_one->label(), $links[0]->getTitle());
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-2512

### Description

Make sure the manual links source respects the limit parameter.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: Make sure the manual links source respects the limit parameter.
- Security:

### Commands

```sh
[Insert commands here]

```

