### PR TITLE
OPENEUROPA-2732: Add render cache keys and test.

### DIFF
--- a/src/LinkListViewBuilder.php
+++ b/src/LinkListViewBuilder.php
@@ -287,4 +287,24 @@ class LinkListViewBuilder extends EntityViewBuilder {
     return NULL;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  protected function isViewModeCacheable($view_mode) {
+    if ($view_mode === 'default') {
+      // The 'default' is not an actual view mode.
+      return TRUE;
+    }
+
+    $view_modes_info = $this->entityDisplayRepository->getViewModes($this->entityTypeId);
+
+    // If the requested view mode is not set, the view builder will use the
+    // default view mode.
+    if (!isset($view_modes_info[$view_mode])) {
+      return TRUE;
+    }
+
+    return !empty($view_modes_info[$view_mode]['cache']);
+  }
+
 }

--- a/src/LinkListViewBuilder.php
+++ b/src/LinkListViewBuilder.php
@@ -137,20 +137,18 @@ class LinkListViewBuilder extends EntityViewBuilder {
 
         $display = $displays[$entity->bundle()];
 
-        $this->moduleHandler()->invokeAll(
-          $view_hook,
-          [&$build_list[$key],
-            $entity,
-            $display,
-            $view_mode,
-          ]);
-        $this->moduleHandler()->invokeAll(
-          'entity_view',
-          [&$build_list[$key],
-            $entity,
-            $display,
-            $view_mode,
-          ]);
+        $this->moduleHandler()->invokeAll($view_hook, [
+          &$build_list[$key],
+          $entity,
+          $display,
+          $view_mode,
+        ]);
+        $this->moduleHandler()->invokeAll('entity_view', [
+          &$build_list[$key],
+          $entity,
+          $display,
+          $view_mode,
+        ]);
 
         $this->addContextualLinks($build_list[$key], $entity);
         $this->alterBuild($build_list[$key], $entity, $display, $view_mode);
@@ -298,8 +296,9 @@ class LinkListViewBuilder extends EntityViewBuilder {
 
     $view_modes_info = $this->entityDisplayRepository->getViewModes($this->entityTypeId);
 
-    // If the requested view mode is not set, the view builder will use the
-    // default view mode.
+    // If the requested view mode is not set, the view builder will use either
+    // the default view mode or a temporary view mode. In order to avoid
+    // re-rendering, we assume non-existing view modes to be cacheable.
     if (!isset($view_modes_info[$view_mode])) {
       return TRUE;
     }

--- a/tests/Kernel/LinkListViewBuilderTest.php
+++ b/tests/Kernel/LinkListViewBuilderTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Drupal\Tests\oe_link_lists\Functional;
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests that link lists are properly cached.
+ */
+class LinkListViewBuilderTest extends KernelTestBase {
+
+  /**
+   * The block storage.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $storage;
+
+  /**
+   * Link list to test.
+   *
+   * @var \Drupal\oe_link_lists\Entity\LinkListInterface
+   */
+  protected $linkList;
+
+  /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'oe_link_lists',
+    'oe_link_lists_test',
+    'system',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('link_list');
+    $this->installConfig([
+      'oe_link_lists',
+      'system',
+    ]);
+
+    $this->storage = $this->container->get('entity_type.manager')->getStorage('link_list');
+
+    // Create a block with only required values.
+    $this->linkList = $this->storage->create([
+      'bundle' => 'dynamic',
+      'title' => 'My link list',
+      'administrative_title' => 'Link list 1',
+    ]);
+    $configuration = [
+      'source' => [
+        'plugin' => 'foo',
+      ],
+      'display' => [
+        'plugin' => 'foo',
+        'plugin_configuration' => ['link' => FALSE],
+      ],
+    ];
+    $this->linkList->setConfiguration($configuration);
+    $this->linkList->save();
+
+    $this->container->get('cache.render')->deleteAll();
+
+    $this->renderer = $this->container->get('renderer');
+  }
+
+  /**
+   * Tests link list render cache handling.
+   */
+  public function testLinkListViewBuilderCache() {
+    // Force a request via GET so we can test the render cache.
+    $request = \Drupal::request();
+    $request_method = $request->server->get('REQUEST_METHOD');
+    $request->setMethod('GET');
+
+    // Test that a cache entry is created.
+    $build = $this->container->get('entity_type.manager')->getViewBuilder('link_list')->view($this->linkList, 'full');
+    $cid_parts = array_merge($build['#cache']['keys'], \Drupal::service('cache_contexts_manager')->convertTokensToKeys([
+      'languages:' . LanguageInterface::TYPE_INTERFACE,
+      'theme',
+      'user.permissions',
+    ])->getKeys());
+    $cid = implode(':', $cid_parts);
+    $bin = $build['#cache']['bin'];
+
+    $this->renderer->renderRoot($build);
+    $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');
+
+    // Re-save the block and check that the cache entry has been deleted.
+    $this->linkList->save();
+    $this->assertFalse($this->container->get('cache.' . $bin)->get($cid), 'The link list render cache entry has been cleared when the link list was saved.');
+
+    // Rebuild the render array (creating a new cache entry in the process) and
+    // delete the block to check the cache entry is deleted.
+    unset($build['#printed']);
+    $this->renderer->renderRoot($build);
+    $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');
+    $this->linkList->delete();
+    $this->assertFalse($this->container->get('cache.' . $bin)->get($cid), 'The link list render cache entry has been cleared when the link list was deleted.');
+
+    // Restore the previous request method.
+    $request->setMethod($request_method);
+  }
+
+}

--- a/tests/Kernel/LinkListViewBuilderTest.php
+++ b/tests/Kernel/LinkListViewBuilderTest.php
@@ -11,13 +11,6 @@ use Drupal\KernelTests\KernelTestBase;
 class LinkListViewBuilderTest extends KernelTestBase {
 
   /**
-   * The block storage.
-   *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
-   */
-  protected $storage;
-
-  /**
    * Link list to test.
    *
    * @var \Drupal\oe_link_lists\Entity\LinkListInterface
@@ -53,10 +46,10 @@ class LinkListViewBuilderTest extends KernelTestBase {
       'system',
     ]);
 
-    $this->storage = $this->container->get('entity_type.manager')->getStorage('link_list');
+    $storage = $this->container->get('entity_type.manager')->getStorage('link_list');
 
-    // Create a block with only required values.
-    $this->linkList = $this->storage->create([
+    // Create a link list with only required values.
+    $this->linkList = $storage->create([
       'bundle' => 'dynamic',
       'title' => 'My link list',
       'administrative_title' => 'Link list 1',
@@ -100,12 +93,12 @@ class LinkListViewBuilderTest extends KernelTestBase {
     $this->renderer->renderRoot($build);
     $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');
 
-    // Re-save the block and check that the cache entry has been deleted.
+    // Re-save the link list and check that the cache entry has been deleted.
     $this->linkList->save();
     $this->assertFalse($this->container->get('cache.' . $bin)->get($cid), 'The link list render cache entry has been cleared when the link list was saved.');
 
     // Rebuild the render array (creating a new cache entry in the process) and
-    // delete the block to check the cache entry is deleted.
+    // delete the link list to check the cache entry is deleted.
     unset($build['#printed']);
     $this->renderer->renderRoot($build);
     $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');

--- a/tests/Kernel/LinkListViewBuilderTest.php
+++ b/tests/Kernel/LinkListViewBuilderTest.php
@@ -1,33 +1,20 @@
 <?php
 
+declare(strict_types = 1);
+
 namespace Drupal\Tests\oe_link_lists\Functional;
 
-use Drupal\Core\Language\LanguageInterface;
 use Drupal\KernelTests\KernelTestBase;
 
 /**
- * Tests that link lists are properly cached.
+ * Tests the link list view builder.
  */
 class LinkListViewBuilderTest extends KernelTestBase {
 
   /**
-   * Link list to test.
-   *
-   * @var \Drupal\oe_link_lists\Entity\LinkListInterface
-   */
-  protected $linkList;
-
-  /**
-   * The renderer.
-   *
-   * @var \Drupal\Core\Render\RendererInterface
-   */
-  protected $renderer;
-
-  /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'oe_link_lists',
     'oe_link_lists_test',
     'system',
@@ -46,67 +33,89 @@ class LinkListViewBuilderTest extends KernelTestBase {
       'system',
     ]);
 
+    $mode_storage = $this->container->get('entity_type.manager')->getStorage('entity_view_mode');
+    $display_repository = $this->container->get('entity_display.repository');
+    // Create a cacheable and an uncacheable view modes and displays for
+    // link list entities.
+    $view_modes = [
+      'cacheable' => TRUE,
+      'uncacheable' => FALSE,
+    ];
+    foreach ($view_modes as $mode => $cacheable) {
+      $mode_storage->create([
+        'id' => 'link_list.' . $mode,
+        'targetEntityType' => 'link_list',
+        'bundle' => 'dynamic',
+        'status' => TRUE,
+        'cache' => $cacheable,
+      ])->save();
+      $display_repository->getViewDisplay('link_list', 'dynamic', $mode)->save();
+    }
+  }
+
+  /**
+   * Tests link list render cache handling.
+   *
+   * The class \Drupal\oe_link_lists\LinkListViewBuilder, compared to the core
+   * entity view builder, allows to cache non-existing view modes.
+   *
+   * @see \Drupal\oe_link_lists\LinkListViewBuilder::isViewModeCacheable()
+   */
+  public function testLinkListViewBuilderCache() {
     $storage = $this->container->get('entity_type.manager')->getStorage('link_list');
+    $view_builder = $this->container->get('entity_type.manager')->getViewBuilder('link_list');
 
     // Create a link list with only required values.
-    $this->linkList = $storage->create([
+    $link_list = $storage->create([
       'bundle' => 'dynamic',
       'title' => 'My link list',
       'administrative_title' => 'Link list 1',
     ]);
     $configuration = [
       'source' => [
-        'plugin' => 'foo',
+        'plugin' => 'baz',
       ],
       'display' => [
         'plugin' => 'foo',
         'plugin_configuration' => ['link' => FALSE],
       ],
     ];
-    $this->linkList->setConfiguration($configuration);
-    $this->linkList->save();
+    $link_list->setConfiguration($configuration);
+    $link_list->save();
 
-    $this->container->get('cache.render')->deleteAll();
+    // Render the entity with a non-existing view mode.
+    $not_existing_view_mode = mb_strtolower($this->randomMachineName());
+    $build = $view_builder->view($link_list, $not_existing_view_mode);
+    // The cache keys should be present, so that the render array can be cached.
+    $this->assertEquals([
+      'entity_view',
+      'link_list',
+      (string) $link_list->id(),
+      $not_existing_view_mode,
+    ], $build['#cache']['keys']);
 
-    $this->renderer = $this->container->get('renderer');
-  }
+    // Verify that the default view mode is always cacheable.
+    $build = $view_builder->view($link_list, 'default');
+    $this->assertEquals([
+      'entity_view',
+      'link_list',
+      (string) $link_list->id(),
+      'default',
+    ], $build['#cache']['keys']);
 
-  /**
-   * Tests link list render cache handling.
-   */
-  public function testLinkListViewBuilderCache() {
-    // Force a request via GET so we can test the render cache.
-    $request = \Drupal::request();
-    $request_method = $request->server->get('REQUEST_METHOD');
-    $request->setMethod('GET');
+    // Verify that an existing view mode with cache enabled is correctly cached.
+    $build = $view_builder->view($link_list, 'cacheable');
+    $this->assertEquals([
+      'entity_view',
+      'link_list',
+      (string) $link_list->id(),
+      'cacheable',
+    ], $build['#cache']['keys']);
 
-    // Test that a cache entry is created.
-    $build = $this->container->get('entity_type.manager')->getViewBuilder('link_list')->view($this->linkList, 'full');
-    $cid_parts = array_merge($build['#cache']['keys'], \Drupal::service('cache_contexts_manager')->convertTokensToKeys([
-      'languages:' . LanguageInterface::TYPE_INTERFACE,
-      'theme',
-      'user.permissions',
-    ])->getKeys());
-    $cid = implode(':', $cid_parts);
-    $bin = $build['#cache']['bin'];
-
-    $this->renderer->renderRoot($build);
-    $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');
-
-    // Re-save the link list and check that the cache entry has been deleted.
-    $this->linkList->save();
-    $this->assertFalse($this->container->get('cache.' . $bin)->get($cid), 'The link list render cache entry has been cleared when the link list was saved.');
-
-    // Rebuild the render array (creating a new cache entry in the process) and
-    // delete the link list to check the cache entry is deleted.
-    unset($build['#printed']);
-    $this->renderer->renderRoot($build);
-    $this->assertTrue($this->container->get('cache.' . $bin)->get($cid), 'The link list render element has been cached.');
-    $this->linkList->delete();
-    $this->assertFalse($this->container->get('cache.' . $bin)->get($cid), 'The link list render cache entry has been cleared when the link list was deleted.');
-
-    // Restore the previous request method.
-    $request->setMethod($request_method);
+    // Verify that an existing view mode with cache disabled does not have
+    // cache keys, meaning that it will not be cached.
+    $build = $view_builder->view($link_list, 'uncacheable');
+    $this->assertArrayNotHasKey('keys', $build['#cache']);
   }
 
 }

--- a/tests/Kernel/LinkListViewBuilderTest.php
+++ b/tests/Kernel/LinkListViewBuilderTest.php
@@ -34,7 +34,7 @@ class LinkListViewBuilderTest extends KernelTestBase {
     ]);
 
     $mode_storage = $this->container->get('entity_type.manager')->getStorage('entity_view_mode');
-    $display_repository = $this->container->get('entity_display.repository');
+    $display_storage = $this->container->get('entity_type.manager')->getStorage('entity_view_display');
     // Create a cacheable and an uncacheable view modes and displays for
     // link list entities.
     $view_modes = [
@@ -49,7 +49,12 @@ class LinkListViewBuilderTest extends KernelTestBase {
         'status' => TRUE,
         'cache' => $cacheable,
       ])->save();
-      $display_repository->getViewDisplay('link_list', 'dynamic', $mode)->save();
+      $display_storage->create([
+        'targetEntityType' => 'link_list',
+        'bundle' => 'dynamic',
+        'mode' => $mode,
+        'status' => TRUE,
+      ])->save();
     }
   }
 


### PR DESCRIPTION
## OPENEUROPA-2732
### Description

Link lists need to provide cache keys so that they are properly cached using the render cache.

### Change log

- Added: Cache keys for link lists
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

