### PR TITLE
OPENEUROPA-2841: Test that access checks on view operations add the entity cacheability metadata.

### DIFF
--- a/modules/oe_link_lists_manual_source/src/LinkListLinkAccessControlHandler.php
+++ b/modules/oe_link_lists_manual_source/src/LinkListLinkAccessControlHandler.php
@@ -26,10 +26,8 @@ class LinkListLinkAccessControlHandler extends EntityAccessControlHandler {
     $type = $entity->bundle();
     switch ($operation) {
       case 'view':
-        if ($entity->isPublished()) {
-          return AccessResult::allowedIfHasPermission($account, 'view link list link');
-        }
-        return AccessResult::allowedIfHasPermission($account, 'view unpublished link list link');
+        $permission = $entity->isPublished() ? 'view link list link' : 'view unpublished link list link';
+        return AccessResult::allowedIfHasPermission($account, $permission)->addCacheableDependency($entity);
 
       case 'update':
         return AccessResult::allowedIfHasPermission($account, 'edit ' . $type . ' link list link');

--- a/modules/oe_link_lists_manual_source/tests/Kernel/LinkListLinkAccessControlHandlerTest.php
+++ b/modules/oe_link_lists_manual_source/tests/Kernel/LinkListLinkAccessControlHandlerTest.php
@@ -72,7 +72,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
   /**
    * Ensures link list link access is properly working.
    */
-  public function testAccess() {
+  public function testAccess(): void {
     $scenarios = $this->accessDataProvider();
     $link_list_link_storage = $this->entityTypeManager->getStorage('link_list_link');
     $values = [
@@ -98,7 +98,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
   /**
    * Ensures link list link create access is properly working.
    */
-  public function testCreateAccess() {
+  public function testCreateAccess(): void {
     $scenarios = $this->createAccessDataProvider();
     foreach ($scenarios as $scenario => $test_data) {
       $user = $this->drupalCreateUser($test_data['permissions']);
@@ -119,7 +119,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
    * @return array
    *   The data sets to test.
    */
-  protected function accessDataProvider() {
+  protected function accessDataProvider(): array {
     return [
       'user without permissions / published link list link' => [
         'permissions' => [],
@@ -259,7 +259,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
    * @return array
    *   The data sets to test.
    */
-  protected function createAccessDataProvider() {
+  protected function createAccessDataProvider(): array {
     return [
       'user without permissions' => [
         'permissions' => [],

--- a/modules/oe_link_lists_manual_source/tests/Kernel/LinkListLinkAccessControlHandlerTest.php
+++ b/modules/oe_link_lists_manual_source/tests/Kernel/LinkListLinkAccessControlHandlerTest.php
@@ -79,10 +79,14 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
       'bundle' => 'test',
       'administrative_title' => $this->randomString(),
     ];
+
+    // Create a link list link.
+    /** @var \Drupal\oe_link_lists_manual_source\Entity\LinkListLink $link_list_link */
+    $link_list_link = $link_list_link_storage->create($values);
+    $link_list_link->save();
+
     foreach ($scenarios as $scenario => $test_data) {
-      // Create a link list link.
-      /** @var \Drupal\oe_link_lists_manual_source\Entity\LinkListLink $link_list_link */
-      $link_list_link = $link_list_link_storage->create($values);
+      // Update the published status based on the scenario.
       $link_list_link->setPublished($test_data['published']);
       $link_list_link->save();
 
@@ -124,13 +128,13 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
       'user without permissions / published link list link' => [
         'permissions' => [],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => TRUE,
       ],
       'user without permissions / unpublished link list link' => [
         'permissions' => [],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => FALSE,
       ],
       'admin view' => [
@@ -160,25 +164,25 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
       'user with view access / published link list link' => [
         'permissions' => ['view link list link'],
         'operation' => 'view',
-        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => TRUE,
       ],
       'user with view access / unpublished link list link' => [
         'permissions' => ['view link list link'],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => FALSE,
       ],
       'user with view unpublished access / published link list link' => [
         'permissions' => ['view unpublished link list link'],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => TRUE,
       ],
       'user with view unpublished access / unpublished link list link' => [
         'permissions' => ['view unpublished link list link'],
         'operation' => 'view',
-        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => FALSE,
       ],
       'user with create, update, delete access / published link list link' => [
@@ -188,7 +192,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
           'delete test link list link',
         ],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => TRUE,
       ],
       'user with create, update, delete access / unpublished link list link' => [
@@ -198,7 +202,7 @@ class LinkListLinkAccessControlHandlerTest extends EntityKernelTestBase {
           'delete test link list link',
         ],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list_link:1']),
         'published' => FALSE,
       ],
       'user with update access' => [

--- a/src/LinkListAccessControlHandler.php
+++ b/src/LinkListAccessControlHandler.php
@@ -26,10 +26,8 @@ class LinkListAccessControlHandler extends EntityAccessControlHandler {
     $type = $entity->bundle();
     switch ($operation) {
       case 'view':
-        if ($entity->isPublished()) {
-          return AccessResult::allowedIfHasPermission($account, 'view link list');
-        }
-        return AccessResult::allowedIfHasPermission($account, 'view unpublished link list');
+        $permission = $entity->isPublished() ? 'view link list' : 'view unpublished link list';
+        return AccessResult::allowedIfHasPermission($account, $permission)->addCacheableDependency($entity);
 
       case 'update':
         return AccessResult::allowedIfHasPermission($account, 'edit ' . $type . ' link list');

--- a/tests/Kernel/LinkListAccessControlHandlerTest.php
+++ b/tests/Kernel/LinkListAccessControlHandlerTest.php
@@ -64,10 +64,14 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
       'bundle' => 'test',
       'administrative_title' => $this->randomString(),
     ];
+
+    // Create a link list.
+    /** @var \Drupal\oe_link_lists\Entity\LinkList $link_list */
+    $link_list = $link_list_storage->create($values);
+    $link_list->save();
+
     foreach ($scenarios as $scenario => $test_data) {
-      /** @var \Drupal\oe_link_lists\Entity\LinkList $link_list */
-      // Create a link list.
-      $link_list = $link_list_storage->create($values);
+      // Update the published status based on the scenario.
       $link_list->setPublished($test_data['published']);
       $link_list->save();
 
@@ -109,13 +113,13 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
       'user without permissions / published link list' => [
         'permissions' => [],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => TRUE,
       ],
       'user without permissions / unpublished link list' => [
         'permissions' => [],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => FALSE,
       ],
       'admin view' => [
@@ -145,25 +149,25 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
       'user with view access / published link list' => [
         'permissions' => ['view link list'],
         'operation' => 'view',
-        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => TRUE,
       ],
       'user with view access / unpublished link list' => [
         'permissions' => ['view link list'],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => FALSE,
       ],
       'user with view unpublished access / published link list' => [
         'permissions' => ['view unpublished link list'],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => TRUE,
       ],
       'user with view unpublished access / unpublished link list' => [
         'permissions' => ['view unpublished link list'],
         'operation' => 'view',
-        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::allowed()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => FALSE,
       ],
       'user with create, update, delete access / published link list' => [
@@ -173,7 +177,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
           'delete test link list',
         ],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => TRUE,
       ],
       'user with create, update, delete access / unpublished link list' => [
@@ -183,7 +187,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
           'delete test link list',
         ],
         'operation' => 'view',
-        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions']),
+        'expected_result' => AccessResult::neutral()->addCacheContexts(['user.permissions'])->addCacheTags(['link_list:1']),
         'published' => FALSE,
       ],
       'user with update access' => [

--- a/tests/Kernel/LinkListAccessControlHandlerTest.php
+++ b/tests/Kernel/LinkListAccessControlHandlerTest.php
@@ -57,7 +57,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
   /**
    * Ensures link list access is properly working.
    */
-  public function testAccess() {
+  public function testAccess(): void {
     $scenarios = $this->accessDataProvider();
     $link_list_storage = $this->container->get('entity_type.manager')->getStorage('link_list');
     $values = [
@@ -83,7 +83,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
   /**
    * Ensures link list create access is properly working.
    */
-  public function testCreateAccess() {
+  public function testCreateAccess(): void {
     $scenarios = $this->createAccessDataProvider();
     foreach ($scenarios as $scenario => $test_data) {
       $user = $this->drupalCreateUser($test_data['permissions']);
@@ -104,7 +104,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
    * @return array
    *   The data sets to test.
    */
-  protected function accessDataProvider() {
+  protected function accessDataProvider(): array {
     return [
       'user without permissions / published link list' => [
         'permissions' => [],
@@ -244,7 +244,7 @@ class LinkListAccessControlHandlerTest extends EntityKernelTestBase {
    * @return array
    *   The data sets to test.
    */
-  protected function createAccessDataProvider() {
+  protected function createAccessDataProvider(): array {
     return [
       'user without permissions' => [
         'permissions' => [],

--- a/tests/Traits/AssertAccessTrait.php
+++ b/tests/Traits/AssertAccessTrait.php
@@ -23,7 +23,7 @@ trait AssertAccessTrait {
    * @param string $message
    *   Failure message.
    */
-  protected function assertAccessResult(AccessResultInterface $expected, AccessResultInterface $actual, string $message = '') {
+  protected function assertAccessResult(AccessResultInterface $expected, AccessResultInterface $actual, string $message = ''): void {
     $this->assertEquals($expected->isAllowed(), $actual->isAllowed(), $message);
     $this->assertEquals($expected->isForbidden(), $actual->isForbidden(), $message);
     $this->assertEquals($expected->isNeutral(), $actual->isNeutral(), $message);


### PR DESCRIPTION
## OPENEUROPA-2841
### Description

Access check handlers implemented in oe_link_lists check for the published status of the entity when evaluating the view access. The entity is not added as cache dependency, thus when the status changes the caches are not invalidated.
Add the correct dependency and fix the tests. This is valid for both link lists and link list links.

### Change log

- Added: Extra checks for entity cache tags.
- Changed:
- Deprecated:
- Removed:
- Fixed: Added entity cacheability to the access checks for link and link lists.
- Security:

### Commands

```sh
[Insert commands here]

```

