### PR TITLE
OPENEUROPA-2853: Fix inline entity form version to 1.0-rc2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,11 +54,6 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
-        "patches": {
-            "drupal/inline_entity_form": {
-                "https://www.drupal.org/project/inline_entity_form/issues/2367235": "https://www.drupal.org/files/issues/2019-10-07/inline_entity_form-2367235-131.patch"
-            }
-        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^7.1",
         "drupal/core": "^8.7",
         "drupal/entity_reference_revisions": "^1.7",
-        "drupal/inline_entity_form": "^1.0@RC"
+        "drupal/inline_entity_form": "^1.0-rc3"
     },
     "require-dev": {
         "composer/installers": "~1.5",


### PR DESCRIPTION
## OPENEUROPA-2853

### Description

Fix inline entity form version to 1.0-rc2 and apply patches.

### Change log

- Added:
- Changed: IEF version
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh

```

