### PR TITLE
OPENEUROPA-0001: Use drupal/core instead of drupal/core-recommended.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.1",
-        "drupal/core-recommended": "^8.7",
+        "drupal/core": "^8.7",
         "drupal/entity_reference_revisions": "^1.7",
         "drupal/inline_entity_form": "^1.0-rc3"
     },


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

