### PR TITLE
OPENEUROPA-3315: Deprecating manual links resolver

### DIFF
--- a/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
+++ b/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
@@ -98,7 +98,7 @@ class LinkListLink extends EditorialContentEntityBase implements LinkListLinkInt
     $event_dispatcher->dispatch(ManualLinkResolverEvent::NAME, $event);
     $link = $event->hasLink() ? $event->getLink() : NULL;
     $bundle = \Drupal::entityTypeManager()->getStorage('link_list_link_type')->load($this->bundle())->label();
-    $title = $link instanceof LinkInterface ? $link->getTitle() : t('Unresolved');
+    $title = $link instanceof LinkInterface ? $link->getTitle() : $this->t('Unresolved');
     return $this->t('@bundle link: @title', ['@bundle' => $bundle, '@title' => $title]);
   }
 

--- a/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
+++ b/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
@@ -12,6 +12,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\NodeInterface;
+use Drupal\oe_link_lists\LinkInterface;
 use Drupal\oe_link_lists_manual_source\Event\ManualLinkResolverEvent;
 
 /**
@@ -95,9 +96,10 @@ class LinkListLink extends EditorialContentEntityBase implements LinkListLinkInt
     $event_dispatcher = \Drupal::service('event_dispatcher');
     $event = new ManualLinkResolverEvent($this);
     $event_dispatcher->dispatch(ManualLinkResolverEvent::NAME, $event);
-    $link = $event->getLink();
+    $link = $event->hasLink() ? $event->getLink() : NULL;
     $bundle = \Drupal::entityTypeManager()->getStorage('link_list_link_type')->load($this->bundle())->label();
-    return $this->t('@bundle link: @title', ['@bundle' => $bundle, '@title' => $link->getTitle()]);
+    $title = $link instanceof LinkInterface ? $link->getTitle() : t('Unresolved');
+    return $this->t('@bundle link: @title', ['@bundle' => $bundle, '@title' => $title]);
   }
 
   /**

--- a/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
+++ b/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
@@ -12,6 +12,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\node\NodeInterface;
+use Drupal\oe_link_lists_manual_source\Event\ManualLinkResolverEvent;
 
 /**
  * Defines the LinkListLink entity.
@@ -91,8 +92,12 @@ class LinkListLink extends EditorialContentEntityBase implements LinkListLinkInt
       return $this->t('Internal link to: @internal_entity', ['@internal_entity' => $target->label()]);
     }
 
+    $event_dispatcher = \Drupal::service('event_dispatcher');
+    $event = new ManualLinkResolverEvent($this);
+    $event_dispatcher->dispatch(ManualLinkResolverEvent::NAME, $event);
+    $link = $event->getLink();
     $bundle = \Drupal::entityTypeManager()->getStorage('link_list_link_type')->load($this->bundle())->label();
-    return $this->t('@bundle link: @title', ['@bundle' => $bundle, '@title' => $this->getTitle()]);
+    return $this->t('@bundle link: @title', ['@bundle' => $bundle, '@title' => $link->getTitle()]);
   }
 
   /**

--- a/modules/oe_link_lists_manual_source/src/Event/ManualLinkResolverEvent.php
+++ b/modules/oe_link_lists_manual_source/src/Event/ManualLinkResolverEvent.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_link_lists_manual_source\Event;
+
+use Drupal\oe_link_lists\LinkInterface;
+use Drupal\oe_link_lists_manual_source\Entity\LinkListLinkInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event class used for resolving a manually created link into a link object.
+ */
+class ManualLinkResolverEvent extends Event {
+
+  /**
+   * The name of the event.
+   */
+  const NAME = 'oe_link_lists.event.manual_link_resolver';
+
+  /**
+   * The link entity.
+   *
+   * @var \Drupal\oe_link_lists_manual_source\Entity\LinkListLinkInterface
+   */
+  protected $linkEntity = [];
+
+  /**
+   * The resolved link.
+   *
+   * @var \Drupal\oe_link_lists\LinkInterface
+   */
+  protected $link = NULL;
+
+  /**
+   * ManualLinkResolverEvent constructor.
+   *
+   * @param \Drupal\oe_link_lists_manual_source\Entity\LinkListLinkInterface $link_entity
+   *   The link entity.
+   */
+  public function __construct(LinkListLinkInterface $link_entity) {
+    $this->linkEntity = $link_entity;
+  }
+
+  /**
+   * Returns the link entities.
+   *
+   * @return \Drupal\oe_link_lists_manual_source\Entity\LinkListLinkInterface
+   *   The link entities.
+   */
+  public function getLinkEntity(): LinkListLinkInterface {
+    return $this->linkEntity;
+  }
+
+  /**
+   * Returns the link object.
+   *
+   * @return \Drupal\oe_link_lists\LinkInterface
+   *   The link object.
+   */
+  public function getLink(): LinkInterface {
+    return $this->link;
+  }
+
+  /**
+   * Sets the link object.
+   *
+   * @param \Drupal\oe_link_lists\LinkInterface $link
+   *   The link object.
+   */
+  public function setLink(LinkInterface $link): void {
+    $this->link = $link;
+  }
+
+}

--- a/modules/oe_link_lists_manual_source/src/Event/ManualLinkResolverEvent.php
+++ b/modules/oe_link_lists_manual_source/src/Event/ManualLinkResolverEvent.php
@@ -53,6 +53,16 @@ class ManualLinkResolverEvent extends Event {
   }
 
   /**
+   * Checks whether the link was resolved.
+   *
+   * @return bool
+   *   Whether the link has been resolved or not.
+   */
+  public function hasLink(): bool {
+    return $this->link instanceof LinkInterface;
+  }
+
+  /**
    * Returns the link object.
    *
    * @return \Drupal\oe_link_lists\LinkInterface

--- a/modules/oe_link_lists_manual_source/src/Event/ManualLinksResolverEvent.php
+++ b/modules/oe_link_lists_manual_source/src/Event/ManualLinksResolverEvent.php
@@ -9,6 +9,9 @@ use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Event class used for resolving a manually created links into link objects.
+ *
+ * @deprecated in oe_link_lists 0.7.0 and will be removed in 1.0.0. Use
+ *   ManualLinkResolverEvent instead.
  */
 class ManualLinksResolverEvent extends Event {
 

--- a/modules/oe_link_lists_manual_source/src/EventSubscriber/DefaultManualLinksResolverSubscriber.php
+++ b/modules/oe_link_lists_manual_source/src/EventSubscriber/DefaultManualLinksResolverSubscriber.php
@@ -83,7 +83,7 @@ class DefaultManualLinksResolverSubscriber implements EventSubscriberInterface {
    *   The link.
    */
   public function resolveInternalLink(ManualLinkResolverEvent $event): LinkInterface {
-    $link_entity = $event->getLinkEntity();
+    $link_entity = $this->entityRepository->getTranslationFromContext($event->getLinkEntity());
 
     /** @var \Drupal\Core\Entity\ContentEntityInterface $referenced_entity */
     $referenced_entity = $link_entity->get('target')->entity;
@@ -119,7 +119,7 @@ class DefaultManualLinksResolverSubscriber implements EventSubscriberInterface {
    *   The link.
    */
   public function resolveExternalLink(ManualLinkResolverEvent $event): LinkInterface {
-    $link_entity = $event->getLinkEntity();
+    $link_entity = $this->entityRepository->getTranslationFromContext($event->getLinkEntity());
 
     try {
       $url = Url::fromUri($link_entity->get('url')->uri);

--- a/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
+++ b/modules/oe_link_lists_manual_source/src/Plugin/LinkSource/ManualLinkSource.php
@@ -142,8 +142,8 @@ class ManualLinkSource extends LinkSourcePluginBase implements ContainerFactoryP
     foreach ($link_entities as $link_entity) {
       $event = new ManualLinkResolverEvent($link_entity);
       $this->eventDispatcher->dispatch(ManualLinkResolverEvent::NAME, $event);
-      $link = $event->getLink();
-      if ($link) {
+      if ($event->hasLink()) {
+        $link = $event->getLink();
         $link->addCacheableDependency($link_entity);
         $links->add($link);
       }

--- a/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
+++ b/modules/oe_link_lists_manual_source/tests/Kernel/ManualLinkSourcePluginTest.php
@@ -70,7 +70,7 @@ class ManualLinkSourcePluginTest extends KernelTestBase {
     // Create a node to be used by an internal link.
     $node_one = $this->createNode(['type' => 'page']);
 
-    // Create an internal link and an external link.
+    // Create an internal content, external and internal route link.
     $entity_type_manager = $this->container->get('entity_type.manager');
     $link_storage = $entity_type_manager->getStorage('link_list_link');
     $internal_link_one = $link_storage->create([
@@ -117,7 +117,16 @@ class ManualLinkSourcePluginTest extends KernelTestBase {
     $plugin = $plugin_manager->createInstance('manual_links', $plugin_configuration);
 
     $links = $plugin->getLinks();
+    // Only the internal content and external links get resolved.
+    $this->assertCount(2, $links);
+
+    // Enable the resolver.
+    $this->container->get('state')->set('oe_link_lists_manual_source_test_subscriber_resolve', TRUE);
+
+    // Now there should be 3 links.
+    $links = $plugin->getLinks();
     $this->assertCount(3, $links);
+
     $this->assertEquals('Example title', $links[0]->getTitle());
     $this->assertEquals($node_one->label(), $links[1]->getTitle());
     $this->assertEquals('User page', $links[2]->getTitle());

--- a/modules/oe_link_lists_manual_source/tests/modules/oe_link_lists_manual_source_test/oe_link_lists_manual_source_test.services.yml
+++ b/modules/oe_link_lists_manual_source/tests/modules/oe_link_lists_manual_source_test/oe_link_lists_manual_source_test.services.yml
@@ -1,0 +1,6 @@
+services:
+  oe_link_lists_manual_source_test.event_subscriber.internal_route_manual_links_resolver:
+    class: Drupal\oe_link_lists_manual_source_test\EventSubscriber\InternalRouteManualLinksResolverSubscriber
+    arguments: ['@state']
+    tags:
+      - { name: event_subscriber }

--- a/modules/oe_link_lists_manual_source/tests/modules/oe_link_lists_manual_source_test/src/EventSubscriber/InternalRouteManualLinksResolverSubscriber.php
+++ b/modules/oe_link_lists_manual_source/tests/modules/oe_link_lists_manual_source_test/src/EventSubscriber/InternalRouteManualLinksResolverSubscriber.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_link_lists_manual_source_test\EventSubscriber;
+
+use Drupal\Core\State\State;
+use Drupal\Core\Url;
+use Drupal\oe_link_lists\DefaultLink;
+use Drupal\oe_link_lists_manual_source\Event\ManualLinkResolverEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Tests subscriber that resolves internal route manual link entities.
+ */
+class InternalRouteManualLinksResolverSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\State
+   */
+  protected $state;
+
+  /**
+   * InternalRouteManualLinksResolverSubscriber constructor.
+   *
+   * @param \Drupal\Core\State\State $state
+   *   The state service.
+   */
+  public function __construct(State $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      ManualLinkResolverEvent::NAME => ['resolveLink', 10],
+    ];
+  }
+
+  /**
+   * Resolves a manual link object from a link list link entity.
+   *
+   * @param \Drupal\oe_link_lists_manual_source\Event\ManualLinkResolverEvent $event
+   *   The event.
+   */
+  public function resolveLink(ManualLinkResolverEvent $event): void {
+    $link_entity = $event->getLinkEntity();
+    if ($link_entity->bundle() !== 'internal_route') {
+      return;
+    }
+
+    // We want to control from the test whether the links should be resolved.
+    if (!$this->state->get('oe_link_lists_manual_source_test_subscriber_resolve', FALSE)) {
+      return;
+    }
+
+    try {
+      $url = Url::fromUri($link_entity->get('url')->uri);
+    }
+    catch (\InvalidArgumentException $exception) {
+      $url = Url::fromRoute('<front>');
+    }
+
+    $link = new DefaultLink($url, $link_entity->getTitle(), ['#markup' => $link_entity->getTeaser()]);
+    $event->setLink($link);
+    $event->stopPropagation();
+  }
+
+}


### PR DESCRIPTION
This PR deprecates the `ManualLinksResolverEvent` of the manual links source in favour of one that resolves each individual link separately called `ManualLinkResolverEvent`. 

If you site subscribes to `ManualLinksResolverEvent`, the individual `ManualLinkResolverEvent` subscriber will not be dispatched so it's recommended you update your subscriber logic in order to benefit from the possibility of using other manual link bundles. 