### PR TITLE
OEL-2324: Source plugin is not passed to display manager in some scenarios

### DIFF
--- a/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
+++ b/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
@@ -410,7 +410,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     // the current link list configuration.
     $link_source_plugin_id = self::getSelectedPlugin('link_source', $form_state);
     if (!$link_source_plugin_id) {
-      $link_source_plugin_id = $this->getConfigurationPluginId($link_list, 'link_source');
+      $link_source_plugin_id = $this->getConfigurationPluginId($link_list, 'source');
     }
 
     $display_plugin_options = $this->linkDisplayPluginManager->getPluginsAsOptions($link_list->bundle(), $link_source_plugin_id);

--- a/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
+++ b/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
@@ -287,10 +287,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     // Keep track of where the plugin ID is coming from so that we know to
     // remove the deprecated ones.
     $remove_deprecated = FALSE;
-    $plugin_id = NestedArray::getValue($form_state->getStorage(), [
-      'plugin_select',
-      'link_source',
-    ]);
+    $plugin_id = self::getSelectedPlugin('link_source', $form_state);
     if (!$plugin_id) {
       $remove_deprecated = TRUE;
       $plugin_id = $this->getConfigurationPluginId($link_list, 'source');
@@ -403,10 +400,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     ];
 
     $link_list = $this->getLinkListFromForm($form, $form_state);
-    $plugin_id = NestedArray::getValue($form_state->getStorage(), [
-      'plugin_select',
-      'link_display',
-    ]);
+    $plugin_id = self::getSelectedPlugin('link_display', $form_state);
     if (!$plugin_id) {
       $plugin_id = $this->getConfigurationPluginId($link_list, 'display');
     }
@@ -414,10 +408,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     // Now we need to determine what is the selected link source plugin. This
     // can be found in two ways: either from the form submission or to check
     // the current link list configuration.
-    $link_source_plugin_id = $form_state->get([
-      'plugin_select',
-      'link_source',
-    ]);
+    $link_source_plugin_id = self::getSelectedPlugin('link_source', $form_state);
     if (!$link_source_plugin_id) {
       $link_source_plugin_id = $this->getConfigurationPluginId($link_list, 'link_source');
     }
@@ -551,10 +542,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
       ],
     ];
 
-    $plugin_id = NestedArray::getValue($form_state->getStorage(), [
-      'plugin_select',
-      'more_link',
-    ]);
+    $plugin_id = self::getSelectedPlugin('more_link', $form_state);
 
     // If we don't have a selected plugin ID, take it from the configuration.
     // However, only do so if we are not part of an Ajax rebuild of the actual
@@ -653,10 +641,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     ];
 
     $link_list = $this->getLinkListFromForm($form, $form_state);
-    $plugin_id = NestedArray::getValue($form_state->getStorage(), [
-      'plugin_select',
-      'no_results_behaviour',
-    ]);
+    $plugin_id = self::getSelectedPlugin('no_results_behaviour', $form_state);
     if (!$plugin_id) {
       $plugin_id = $this->getConfigurationPluginId($link_list, 'no_results_behaviour');
     }
@@ -758,6 +743,24 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
       'plugin_select',
       $type,
     ], $value);
+  }
+
+  /**
+   * Retrieves the selected plugin for a plugin type.
+   *
+   * @param string $type
+   *   The plugin type.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   *
+   * @return string|null
+   *   The plugin ID if found, NULL otherwise.
+   */
+  public static function getSelectedPlugin(string $type, FormStateInterface $form_state): ?string {
+    return NestedArray::getValue($form_state->getStorage(), [
+      'plugin_select',
+      $type,
+    ]);
   }
 
   /**

--- a/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
+++ b/src/Plugin/Field/FieldWidget/LinkListConfigurationWidget.php
@@ -314,6 +314,7 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
     // use that as the default.
     if (!$plugin_id && count($source_plugin_options) === 1) {
       $plugin_id = key($source_plugin_options);
+      self::setSelectedPlugin('link_source', $plugin_id, $form_state);
     }
 
     $element['link_source']['plugin'] = [
@@ -738,11 +739,25 @@ class LinkListConfigurationWidget extends WidgetBase implements ContainerFactory
    */
   public static function selectPlugin(array $form, FormStateInterface $form_state): void {
     $triggering_element = $form_state->getTriggeringElement();
+    self::setSelectedPlugin($triggering_element['#plugin_select'], $triggering_element['#value'], $form_state);
+    $form_state->setRebuild(TRUE);
+  }
+
+  /**
+   * Stores the selected plugin ID for a plugin type.
+   *
+   * @param string $type
+   *   The plugin type.
+   * @param string $value
+   *   The plugin ID.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  public static function setSelectedPlugin(string $type, string $value, FormStateInterface $form_state): void {
     NestedArray::setValue($form_state->getStorage(), [
       'plugin_select',
-      $triggering_element['#plugin_select'],
-    ], $triggering_element['#value']);
-    $form_state->setRebuild(TRUE);
+      $type,
+    ], $value);
   }
 
   /**

--- a/tests/modules/oe_link_lists_test/oe_link_lists_test.module
+++ b/tests/modules/oe_link_lists_test/oe_link_lists_test.module
@@ -30,3 +30,16 @@ function oe_link_lists_test_node_access(EntityInterface $entity, $operation, Acc
 
   return $result;
 }
+
+/**
+ * Implements hook_link_source_info_alter().
+ *
+ * Allow tests to disable the available link source plugins.
+ */
+function oe_link_lists_test_link_source_info_alter(array &$definitions): void {
+  $allowed = \Drupal::state()->get('oe_link_lists_test_allowed_sources');
+
+  if (is_array($allowed)) {
+    $definitions = array_intersect_key($definitions, array_flip($allowed));
+  }
+}

--- a/tests/src/FunctionalJavascript/LinkListConfigurationFormTest.php
+++ b/tests/src/FunctionalJavascript/LinkListConfigurationFormTest.php
@@ -280,6 +280,34 @@ class LinkListConfigurationFormTest extends WebDriverTestBase {
   }
 
   /**
+   * Tests more scenarios for display plugins depending on source plugins.
+   */
+  public function testDisplaySourceDependencies(): void {
+    // Limit sources to only one, so that it will be automatically selected in
+    // the form.
+    \Drupal::state()->set('oe_link_lists_test_allowed_sources', ['test_empty_collection']);
+
+    $this->drupalGet('link_list/add/dynamic');
+    $this->assertFieldSelectOptions('Link source', [
+      'test_empty_collection',
+    ]);
+
+    // The "test_empty_source_only_display" should be available, as it can
+    // be used with the source selected above.
+    $this->assertFieldSelectOptions('Link display', [
+      'same_configuration_display_one',
+      'same_configuration_display_two',
+      'test_configurable_title',
+      'test_empty_source_only_display',
+      'test_link_tag',
+      'test_markup',
+      'test_translatable_form',
+      'test_no_bundle_restriction_display',
+      'title',
+    ]);
+  }
+
+  /**
    * Tests that a list can have a limit and a "More link".
    */
   public function testLinkListMoreLink(): void {

--- a/tests/src/FunctionalJavascript/LinkListConfigurationFormTest.php
+++ b/tests/src/FunctionalJavascript/LinkListConfigurationFormTest.php
@@ -305,6 +305,43 @@ class LinkListConfigurationFormTest extends WebDriverTestBase {
       'test_no_bundle_restriction_display',
       'title',
     ]);
+
+    /** @var \Drupal\oe_link_lists\Entity\LinkListInterface $link_list */
+    $link_list = \Drupal::entityTypeManager()->getStorage('link_list')->create([
+      'bundle' => 'dynamic',
+      'administrative_title' => $this->randomMachineName(),
+    ]);
+    $configuration = [
+      'source' => [
+        'plugin' => 'test_empty_collection',
+        'plugin_configuration' => ['url' => 'http://example.com'],
+      ],
+      'display' => [
+        'plugin' => 'title',
+        'plugin_configuration' => [],
+      ],
+      'no_results_behaviour' => [
+        'plugin' => 'hide_list',
+        'plugin_configuration' => [],
+      ],
+    ];
+    $link_list->setConfiguration($configuration);
+    $link_list->save();
+    // Test that link display filtering is executed on first load of a link list
+    // edit form.
+    $this->drupalGet($link_list->toUrl('edit-form'));
+    // Again the "test_empty_source_only_display" should be available.
+    $this->assertFieldSelectOptions('Link display', [
+      'same_configuration_display_one',
+      'same_configuration_display_two',
+      'test_configurable_title',
+      'test_empty_source_only_display',
+      'test_link_tag',
+      'test_markup',
+      'test_translatable_form',
+      'test_no_bundle_restriction_display',
+      'title',
+    ]);
   }
 
   /**


### PR DESCRIPTION
In `\Drupal\oe_link_lists\Plugin\Field\FieldWidget\LinkListConfigurationWidget::buildLinkDisplayElements()` the link source plugin id is passed to the link display plugin manager to retrieve the compatible display plugins.
This doesn't happen in two scenarios:

1. While editing an existing link list: the call to `getConfigurationPluginId()` should pass "source" as second parameter, not "link_source".
2. When creating a new link list and the source is never changed: the `selectPlugin()` method is not invoked, so the form storage doesn't contain the plugin id, again in `buildLinkDisplayElements()`.