### PR TITLE
OEL-4680: Support formatted text (WYSIWYG) on manual link teaser field.

### DIFF
--- a/modules/oe_link_lists_manual_source/oe_link_lists_manual_source.install
+++ b/modules/oe_link_lists_manual_source/oe_link_lists_manual_source.install
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @file
+ * Install and update functions for OpenEuropa Manual Link Lists module.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Change the teaser base field from string_long to text_long.
+ *
+ * This adds WYSIWYG support and proper HTML rendering for the teaser field
+ * on link_list_link entities.
+ */
+function oe_link_lists_manual_source_update_10001(): string {
+  $entity_type_id = 'link_list_link';
+  $field_name = 'teaser';
+  $default_format = 'simple_rich_text';
+
+  $database = \Drupal::database();
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $entity_definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $entity_type = $entity_type_manager->getDefinition($entity_type_id);
+  $tables = [
+    $entity_type->getDataTable(),
+    $entity_type->getRevisionDataTable(),
+  ];
+
+  // Add the 'format' column to all relevant tables.
+  $format_spec = [
+    'type' => 'varchar_ascii',
+    'length' => 255,
+    'not null' => FALSE,
+  ];
+
+  foreach ($tables as $table) {
+    if ($table && $database->schema()->tableExists($table)) {
+      $format_column = $field_name . '__format';
+      if (!$database->schema()->fieldExists($table, $format_column)) {
+        $database->schema()->addField($table, $format_column, $format_spec);
+      }
+      // Set default format for existing teaser values.
+      $database->update($table)
+        ->fields([$format_column => $default_format])
+        ->isNotNull($field_name)
+        ->condition($field_name, '', '<>')
+        ->execute();
+    }
+  }
+
+  // Update the last installed field storage definition so Drupal knows the
+  // field is now text_long.
+  $field_storage_definition = $entity_definition_update_manager->getFieldStorageDefinition($field_name, $entity_type_id);
+  $entity_definition_update_manager->updateFieldStorageDefinition($field_storage_definition);
+
+  return 'Changed the teaser field from string_long to text_long for WYSIWYG support.';
+}

--- a/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
+++ b/modules/oe_link_lists_manual_source/src/Entity/LinkListLink.php
@@ -190,25 +190,22 @@ class LinkListLink extends EditorialContentEntityBase implements LinkListLinkInt
       ->setDisplayConfigurable('view', TRUE)
       ->setRequired(FALSE);
 
-    $fields['teaser'] = BaseFieldDefinition::create('string_long')
+    $fields['teaser'] = BaseFieldDefinition::create('text_long')
       ->setLabel(t('Teaser'))
       ->setDescription(t('The teaser of the link.'))
       ->setRevisionable(TRUE)
       ->setTranslatable(TRUE)
-      ->setSettings([
-        'max_length' => 2000,
-        'text_processing' => 0,
-      ])
       ->setDefaultValue('')
       ->setDisplayOptions('view', [
         'label' => 'above',
-        'type' => 'string',
+        'type' => 'text_default',
       ])
       ->setDisplayOptions('form', [
-        'type' => 'string_textarea',
+        'type' => 'text_textarea',
         'weight' => 11,
       ])
       ->setDisplayConfigurable('view', TRUE)
+      ->setDisplayConfigurable('form', TRUE)
       ->setRequired(FALSE);
 
     $fields['parent_id'] = BaseFieldDefinition::create('string')

--- a/modules/oe_link_lists_manual_source/src/EventSubscriber/DefaultManualLinksResolverSubscriber.php
+++ b/modules/oe_link_lists_manual_source/src/EventSubscriber/DefaultManualLinksResolverSubscriber.php
@@ -107,10 +107,11 @@ class DefaultManualLinksResolverSubscriber implements EventSubscriberInterface {
       $link->setTitle($link_entity->getTitle());
     }
     if (!$link_entity->get('teaser')->isEmpty()) {
+      $teaser_field = $link_entity->get('teaser')->first();
       $link->setTeaser([
         '#type' => 'processed_text',
-        '#text' => $link_entity->getTeaser(),
-        '#format' => 'plain_text',
+        '#text' => $teaser_field->value,
+        '#format' => $teaser_field->format ?? 'simple_rich_text',
       ]);
     }
 
@@ -143,14 +144,12 @@ class DefaultManualLinksResolverSubscriber implements EventSubscriberInterface {
     }
 
     $teaser = [];
-    // Convert the teaser string to a processed text render array.
-    // This is necessary to ensure that external links can have a teaser
-    // with same rendering as internal links.
-    if ($teaser_text = $link_entity->getTeaser()) {
+    if (!$link_entity->get('teaser')->isEmpty()) {
+      $teaser_field = $link_entity->get('teaser')->first();
       $teaser = [
         '#type' => 'processed_text',
-        '#text' => $teaser_text,
-        '#format' => 'plain_text',
+        '#text' => $teaser_field->value,
+        '#format' => $teaser_field->format ?? 'simple_rich_text',
       ];
     }
 


### PR DESCRIPTION
## Problem

  The `teaser` base field on the `link_list_link` entity is defined as `string_long`, which means:

  - No text format / WYSIWYG editor is available in the edit form.
  - Any HTML typed into the teaser (`<p>`, `<strong>`, `<em>`, …) is escaped on output (users see literal markup on the front-end).

  The `DefaultManualLinksResolverSubscriber` then wraps the teaser in a `#type: processed_text` render array but hardcodes `'#format' => 'plain_text'`, reinforcing the same limitation even if the value contained HTML.

  ## Fix

  1. Change the `teaser` base field from `string_long` to `text_long` so it stores both a `value` and a `format`, enabling text format selection and a WYSIWYG editor in the entity form.

  2. Update `DefaultManualLinksResolverSubscriber` (internal and external link resolvers) to use the format stored on the field instead of hardcoding `plain_text`, falling back to `plain_text` only when the field has no format set.

  3. Add `oe_link_lists_manual_source.install` with `update_10001` that:
     - adds the `teaser__format` column to `link_list_link_field_data` and `link_list_link_field_revision`;
     - sets a default format (`simple_rich_text`) on existing non-empty teaser values so content migrated from the old field renders correctly;
     - applies the updated field storage definition via `EntityDefinitionUpdateManager`.

  ## Upgrade path

  Sites with existing link_list_link entities will need to run `drush updatedb` to pick up the schema change. Existing teaser values
  that were stored as plain text will receive the `simple_rich_text` format by default. Site owners may want to review/adjust this choice after the update.